### PR TITLE
minor fixes to stylize.py, net.py, and torch_to_pytorch.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,31 @@ Given an image dataset, the script creates the specified number of stylized vers
 Feel free to open an issue in case there is any question.
 
 ## Usage
-- dependencies
+- Dependencies:
     - python >= 3.6
     - Pillow
-    - torch
+    - torch==0.4.0
     - torchvision
-    - tqdm
+    - tqdm  
 - Download and convert the models:
     - for this step it is mandatory that your pytorch version is 0.4.0. Run `pip install torch==0.4.0` (preferrably in a container/virtual environment in order to not mess with your local pytorch installation)
-    - Get style images Download train.zip from [Kaggle's painter-by-numbers dataset](https://www.kaggle.com/c/painter-by-numbers/data)
     - run `bash download_convert_models.sh`
-- to stylize a dataset, run `python stylize.py`. Arguments:
-    - `--content-dir <CONTENT>` the top-level directory of the content image dataset (mandatory)
-    - `--style-dir <STLYE>` the top-level directory of the style images (mandatory)
-    - `--output-dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
+    - Get style images Download train.zip from [Kaggle's painter-by-numbers dataset](https://www.kaggle.com/c/painter-by-numbers/data)
+- To stylize a dataset, run `python stylize.py`. 
+     
+    Arguments:
+    - `--content_dir <CONTENT>` the top-level directory of the content image dataset (mandatory)
+    - `--style_dir <STLYE>` the top-level directory of the style images (mandatory)
+    - `--output_dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
     - `--num-styles <N>` number of stylizations to create for each content image (optional, default: `1`)
     - `--alpha <A>` Weight that controls the strength of stylization, should be between 0 and 1 (optional, default: `1`)
     - `--extensions <EX0> <EX1> ...` list of image extensions to scan style and content directory for (optional, default: `png, jpeg, jpg`). Note: this is case sensitive, `--extensions jpg` will not scan for files ending on `.JPG`. Image types must be compatible with PIL's `Image.open()` ([Documentation](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html))
     - `--content_size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
     - `--style_size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
     - `--crop` If set, content and style images will be cropped at the center to create square output images
+
+Here is an example call: 
+
+```
+ python3 stylize.py --content_dir '/home/username/stylize-datasets/images/' --style_dir '/home/username/stylize-datasets/train/' --num-styles 10 --content_size 0 --style_size 0
+ ```

--- a/README.md
+++ b/README.md
@@ -9,28 +9,28 @@ Feel free to open an issue in case there is any question.
 - Dependencies:
     - python >= 3.6
     - Pillow
-    - torch==0.4.0
+    - torch
     - torchvision
     - tqdm  
 - Download and convert the models:
     - for this step it is mandatory that your pytorch version is 0.4.0. Run `pip install torch==0.4.0` (preferrably in a container/virtual environment in order to not mess with your local pytorch installation)
     - run `bash download_convert_models.sh`
-    - Get style images Download train.zip from [Kaggle's painter-by-numbers dataset](https://www.kaggle.com/c/painter-by-numbers/data)
-- To stylize a dataset, run `python stylize.py`. 
-     
+    - Get style images: Download train.zip from [Kaggle's painter-by-numbers dataset](https://www.kaggle.com/c/painter-by-numbers/data)
+- To stylize a dataset, run `python stylize.py`.
+
     Arguments:
-    - `--content_dir <CONTENT>` the top-level directory of the content image dataset (mandatory)
-    - `--style_dir <STLYE>` the top-level directory of the style images (mandatory)
+    - `--content-dir <CONTENT>` the top-level directory of the content image dataset (mandatory)
+    - `--style-dir <STLYE>` the top-level directory of the style images (mandatory)
     - `--output-dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
     - `--num-styles <N>` number of stylizations to create for each content image (optional, default: `1`)
     - `--alpha <A>` Weight that controls the strength of stylization, should be between 0 and 1 (optional, default: `1`)
     - `--extensions <EX0> <EX1> ...` list of image extensions to scan style and content directory for (optional, default: `png, jpeg, jpg`). Note: this is case sensitive, `--extensions jpg` will not scan for files ending on `.JPG`. Image types must be compatible with PIL's `Image.open()` ([Documentation](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html))
-    - `--content_size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
-    - `--style_size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
+    - `--content-size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
+    - `--style-size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
     - `--crop` If set, content and style images will be cropped at the center to create square output images
 
-Here is an example call: 
+Here is an example call:
 
 ```
- python3 stylize.py --content_dir '/home/username/stylize-datasets/images/' --style_dir '/home/username/stylize-datasets/train/' --num-styles 10 --content_size 0 --style_size 0
+ python3 stylize.py --content-dir '/home/username/stylize-datasets/images/' --style-dir '/home/username/stylize-datasets/train/' --num-styles 10 --content_size 0 --style_size 256
  ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Feel free to open an issue in case there is any question.
     - tqdm
 - Download and convert the models:
     - for this step it is mandatory that your pytorch version is 0.4.0. Run `pip install torch==0.4.0` (preferrably in a container/virtual environment in order to not mess with your local pytorch installation)
+    - Get style images Download train.zip from [Kaggle's painter-by-numbers dataset](https://www.kaggle.com/c/painter-by-numbers/data)
     - run `bash download_convert_models.sh`
 - to stylize a dataset, run `python stylize.py`. Arguments:
     - `--content-dir <CONTENT>` the top-level directory of the content image dataset (mandatory)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Feel free to open an issue in case there is any question.
     Arguments:
     - `--content_dir <CONTENT>` the top-level directory of the content image dataset (mandatory)
     - `--style_dir <STLYE>` the top-level directory of the style images (mandatory)
-    - `--output_dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
+    - `--output-dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
     - `--num-styles <N>` number of stylizations to create for each content image (optional, default: `1`)
     - `--alpha <A>` Weight that controls the strength of stylization, should be between 0 and 1 (optional, default: `1`)
     - `--extensions <EX0> <EX1> ...` list of image extensions to scan style and content directory for (optional, default: `png, jpeg, jpg`). Note: this is case sensitive, `--extensions jpg` will not scan for files ending on `.JPG`. Image types must be compatible with PIL's `Image.open()` ([Documentation](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html))

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Feel free to open an issue in case there is any question.
     - `--num-styles <N>` number of stylizations to create for each content image (optional, default: `1`)
     - `--alpha <A>` Weight that controls the strength of stylization, should be between 0 and 1 (optional, default: `1`)
     - `--extensions <EX0> <EX1> ...` list of image extensions to scan style and content directory for (optional, default: `png, jpeg, jpg`). Note: this is case sensitive, `--extensions jpg` will not scan for files ending on `.JPG`. Image types must be compatible with PIL's `Image.open()` ([Documentation](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html))
-    - `--content-size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
-    - `--style-size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
+    - `--content_size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
+    - `--style_size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
     - `--crop` If set, content and style images will be cropped at the center to create square output images

--- a/net.py
+++ b/net.py
@@ -8,7 +8,7 @@ decoder = nn.Sequential(
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(512, 256, (3, 3)),
     nn.ReLU(),
-    nn.Upsample(scale_factor=2), #changed
+    nn.Upsample(scale_factor=2),
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(256, 256, (3, 3)),
     nn.ReLU(),
@@ -21,14 +21,14 @@ decoder = nn.Sequential(
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(256, 128, (3, 3)),
     nn.ReLU(),
-    nn.Upsample(scale_factor=2), #changed
+    nn.Upsample(scale_factor=2),
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(128, 128, (3, 3)),
     nn.ReLU(),
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(128, 64, (3, 3)),
     nn.ReLU(),
-    nn.Upsample(scale_factor=2), #changed
+    nn.Upsample(scale_factor=2),
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(64, 64, (3, 3)),
     nn.ReLU(),

--- a/net.py
+++ b/net.py
@@ -8,7 +8,7 @@ decoder = nn.Sequential(
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(512, 256, (3, 3)),
     nn.ReLU(),
-    nn.UpsamplingNearest2d(scale_factor=2),
+    nn.Upsample(scale_factor=2), #changed
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(256, 256, (3, 3)),
     nn.ReLU(),
@@ -21,14 +21,14 @@ decoder = nn.Sequential(
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(256, 128, (3, 3)),
     nn.ReLU(),
-    nn.UpsamplingNearest2d(scale_factor=2),
+    nn.Upsample(scale_factor=2), #changed
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(128, 128, (3, 3)),
     nn.ReLU(),
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(128, 64, (3, 3)),
     nn.ReLU(),
-    nn.UpsamplingNearest2d(scale_factor=2),
+    nn.Upsample(scale_factor=2), #changed
     nn.ReflectionPad2d((1, 1, 1, 1)),
     nn.Conv2d(64, 64, (3, 3)),
     nn.ReLU(),

--- a/stylize.py
+++ b/stylize.py
@@ -12,9 +12,9 @@ from torchvision.utils import save_image
 from tqdm import tqdm
 
 parser = argparse.ArgumentParser(description='This script applies the AdaIN style transfer method to arbitrary datasets.')
-parser.add_argument('--content_dir', type=str,
+parser.add_argument('--content-dir', type=str,
                     help='Directory path to a batch of content images')
-parser.add_argument('--style_dir', type=str,
+parser.add_argument('--style-dir', type=str,
                     help='Directory path to a batch of style images')
 parser.add_argument('--output-dir', type=str, default='output',
                     help='Directory to save the output images')
@@ -26,10 +26,10 @@ parser.add_argument('--alpha', type=float, default=1.0,
 parser.add_argument('--extensions', nargs='+', type=str, default=['png', 'jpeg', 'jpg'], help='List of image extensions to scan style and content directory for (case sensitive), default: png, jpeg, jpg')
 
 # Advanced options
-parser.add_argument('--content_size', type=int, default=0,
+parser.add_argument('--content-size', type=int, default=0,
                     help='New (minimum) size for the content image, \
                     keeping the original size if set to 0')
-parser.add_argument('--style_size', type=int, default=512,
+parser.add_argument('--style-size', type=int, default=512,
                     help='New (minimum) size for the style image, \
                     keeping the original size if set to 0')
 parser.add_argument('--crop', action='store_true',

--- a/stylize.py
+++ b/stylize.py
@@ -141,7 +141,7 @@ def main():
                 out_filename = content_name + '-stylized-' + style_name + content_path.suffix
                 output_name = out_dir.joinpath(out_filename)
 
-                save_image(output, output_name)
+                save_image(output, output_name, padding=0) #default image padding is 2.
                 content_img.close()
                 style_img.close()
                 pbar.update(1)

--- a/stylize.py
+++ b/stylize.py
@@ -12,9 +12,9 @@ from torchvision.utils import save_image
 from tqdm import tqdm
 
 parser = argparse.ArgumentParser(description='This script applies the AdaIN style transfer method to arbitrary datasets.')
-parser.add_argument('--content-dir', type=str,
+parser.add_argument('--content_dir', type=str,
                     help='Directory path to a batch of content images')
-parser.add_argument('--style-dir', type=str,
+parser.add_argument('--style_dir', type=str,
                     help='Directory path to a batch of style images')
 parser.add_argument('--output-dir', type=str, default='output',
                     help='Directory to save the output images')
@@ -93,6 +93,7 @@ def main():
     vgg = net.vgg
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    #device = "cuda"
 
     decoder.eval()
     vgg.eval()

--- a/stylize.py
+++ b/stylize.py
@@ -93,7 +93,6 @@ def main():
     vgg = net.vgg
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    #device = "cuda"
 
     decoder.eval()
     vgg.eval()

--- a/torch_to_pytorch.py
+++ b/torch_to_pytorch.py
@@ -82,7 +82,7 @@ def lua_recursive_model(module, seq):
                              ceil_mode=m.ceil_mode)
             add_submodule(seq, n)
         elif name == 'SpatialUpSamplingNearest':
-            n = nn.UpsamplingNearest2d(scale_factor=m.scale_factor)
+            n = nn.Upsample(scale_factor=m.scale_factor) #changed
             add_submodule(seq, n)
         elif name == 'View':
             n = Lambda(lambda x: x.view(x.size(0), -1))
@@ -176,7 +176,7 @@ def lua_recursive_source(module):
             s += ['nn.AvgPool2d({},{},{},ceil_mode={}),#AvgPool2d'.format(
                 (m.kW, m.kH), (m.dW, m.dH), (m.padW, m.padH), m.ceil_mode)]
         elif name == 'SpatialUpSamplingNearest':
-            s += ['nn.UpsamplingNearest2d(scale_factor={})'.format(
+            s += ['nn.Upsample(scale_factor={})'.format(
                 m.scale_factor)]
         elif name == 'View':
             s += ['Lambda(lambda x: x.view(x.size(0),-1)), # View']

--- a/torch_to_pytorch.py
+++ b/torch_to_pytorch.py
@@ -82,7 +82,7 @@ def lua_recursive_model(module, seq):
                              ceil_mode=m.ceil_mode)
             add_submodule(seq, n)
         elif name == 'SpatialUpSamplingNearest':
-            n = nn.Upsample(scale_factor=m.scale_factor) #changed
+            n = nn.Upsample(scale_factor=m.scale_factor)
             add_submodule(seq, n)
         elif name == 'View':
             n = Lambda(lambda x: x.view(x.size(0), -1))


### PR DESCRIPTION
- fixes to readme and stylize.py to be consistent ( _ vs - )
- fixed padding to zero so input and output context image are the same size
- fixed warning, i.e. swapped out Upsample for UpsamplingNearest3d.  "UserWarning: nn.UpsamplingNearest2d is deprecated. Use nn.Upsample instead."