### PR TITLE
Explicit content style maps for reproducing datasets and manual control 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,21 @@ Feel free to open an issue in case there is any question.
     - `--style-dir <STLYE>` the top-level directory of the style images (mandatory)
     - `--output-dir <OUTPUT>` the directory where the stylized dataset will be stored (optional, default: `output/`)
     - `--num-styles <N>` number of stylizations to create for each content image (optional, default: `1`)
+    - `--style-map <STYLE_MAP>` an explicit content style map json. If provided, num-styles will be ignored (optional, default: `None`)
     - `--alpha <A>` Weight that controls the strength of stylization, should be between 0 and 1 (optional, default: `1`)
     - `--extensions <EX0> <EX1> ...` list of image extensions to scan style and content directory for (optional, default: `png, jpeg, jpg`). Note: this is case sensitive, `--extensions jpg` will not scan for files ending on `.JPG`. Image types must be compatible with PIL's `Image.open()` ([Documentation](https://pillow.readthedocs.io/en/5.1.x/handbook/image-file-formats.html))
     - `--content-size <N>` Minimum size for content images, resulting in scaling of the shorter side of the content image to `N` (optional, default: `0`). Set this to 0 to keep the original image dimensions.
     - `--style-size <N>` Minimum size for style images, resulting in scaling of the shorter side of the style image to `N` (optional, default: `512`). Set this to 0 to keep the original image dimensions (for large style images, this will result in high (GPU) memory consumption).
     - `--crop <N>` Size for the center crop applied to the content image in order to create a squared image (optional, default 0). Setting this to 0 will disable the cropping.
+
+The chosen styles per content image will be saved in a `content_style_map.json`. This file can be used with the `--style-map` argument to reproduce a specific dataset or to create an explicit content style mapping manually. Keys and values must be existing file names in the `--content-dir` and `--style-dir` respectively.
+
+```json
+{ 
+    "content_image_1.jpg": ["style_1.jpg"],
+    "content_image_2.jpg": ["style_2.jpg", "style_3.jpg"]
+}
+```
 
 Here is an example call:
 

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/stylize.py
+++ b/stylize.py
@@ -143,7 +143,7 @@ def main():
 
     # actual style transfer as in AdaIN
     with tqdm(total=len(style_map.keys())) as pbar:
-        for c, s_list in style_map.items():
+        for c, style_list in style_map.items():
             content_path = content_files[c]
             try:
                 content_img = Image.open(content_path).convert('RGB')

--- a/stylize.py
+++ b/stylize.py
@@ -21,6 +21,8 @@ parser.add_argument('--output-dir', type=str, default='output',
                     help='Directory to save the output images')
 parser.add_argument('--num-styles', type=int, default=1, help='Number of styles to \
                         create for each image (default: 1)')
+parser.add_argument('--style-map', type=str, default=None, help='An explicit content-style map \
+                        that is used instead of random sampling. Num styles is ignored in this case.')
 parser.add_argument('--alpha', type=float, default=1.0,
                     help='The weight that controls the degree of \
                           stylization. Should be between 0 and 1')
@@ -105,12 +107,19 @@ def main():
     style_filenames   = list(style_files.keys())
 
     # create the content to style mappings
-    style_map = {}
-    for c in content_filenames:
-        style_list = []
-        for s in random.sample(style_filenames, args.num_styles):
-            style_list.append(s)
-        style_map[c] = style_list
+    if args.style_map is None:
+        print('Create new content-style map with %d random styles per content image.' % args.num_styles)
+        style_map = {}
+        for c in content_filenames:
+            style_list = []
+            for s in random.sample(style_filenames, args.num_styles):
+                style_list.append(s)
+            style_map[c] = style_list
+    else:
+        style_map_path = Path(args.style_map).resolve()
+        print('Load content-style map from %s' % style_map_path)
+        with open(style_map_path) as f:
+            style_map = json.load(f)
 
     # ensure that content and style files exist (e.g. when using an explicit content-style-map)
     for c, s_list in style_map.items():

--- a/stylize.py
+++ b/stylize.py
@@ -186,7 +186,7 @@ def main():
             finally:
                 pbar.update(1)
 
-    with open(output_dir.joinpath('style_map.json'), 'w') as f:
+    with open(output_dir.joinpath('content_style_map.json'), 'w') as f:
         json.dump(style_map, f)
 
     if(len(skipped_imgs) > 0):


### PR DESCRIPTION
This change adds the following features:

- the randomly chosen styles will be saved in a content_style_map.json file.
- this mapping can be used to reproduce datasets or to create explicit mappings manually. (we need this for our research)
- the default behaviour is not changed, only the style map will be saved in addition to the images.
- the rglob search with nested directories will still work as expected since we convert content_paths and style_paths to dictionaries for file_name to path lookup.